### PR TITLE
Add standalone console window for scan output

### DIFF
--- a/chrome-extension/console.css
+++ b/chrome-extension/console.css
@@ -1,0 +1,75 @@
+:root {
+  color-scheme: dark;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background: #060708;
+  color: #e6edf3;
+  font-family: 'Fira Code', 'Source Code Pro', 'Courier New', monospace;
+  font-size: 13px;
+  line-height: 1.4;
+  min-height: 100vh;
+  display: flex;
+}
+
+#terminal {
+  flex: 1;
+  padding: 16px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  background: radial-gradient(circle at top left, rgba(48, 106, 255, 0.12), rgba(0, 0, 0, 0.85) 65%);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+}
+
+.line {
+  margin-bottom: 6px;
+  padding-left: 12px;
+  position: relative;
+}
+
+.line::before {
+  content: '➜';
+  position: absolute;
+  left: 0;
+  color: #4ea1ff;
+}
+
+.line.status {
+  color: #8ab4ff;
+}
+
+.line.success {
+  color: #7ee787;
+}
+
+.line.warn {
+  color: #facc15;
+}
+
+.line.error {
+  color: #ff6b6b;
+}
+
+.line.issue-title {
+  color: #f472b6;
+  font-weight: 600;
+}
+
+.line.meta {
+  color: #9ca8b7;
+  font-style: italic;
+}
+
+.line.match {
+  color: #d1d9e0;
+}
+
+.line + .line.match {
+  margin-top: -2px;
+}
+
+.line:last-child {
+  margin-bottom: 0;
+}

--- a/chrome-extension/console.html
+++ b/chrome-extension/console.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>JS Miner Console</title>
+  <link rel="stylesheet" href="console.css">
+</head>
+<body>
+  <div id="terminal" role="log" aria-live="polite"></div>
+  <script type="module" src="console.js"></script>
+</body>
+</html>

--- a/chrome-extension/console.js
+++ b/chrome-extension/console.js
@@ -1,0 +1,76 @@
+const terminalEl = document.getElementById('terminal');
+const EXTENSION_ORIGIN = new URL(chrome.runtime.getURL('')).origin;
+
+function now() {
+  const date = new Date();
+  return date.toLocaleTimeString([], { hour12: false });
+}
+
+function appendLine(text, variant = 'status') {
+  const line = document.createElement('div');
+  line.className = `line ${variant}`;
+  line.textContent = `[${now()}] ${text}`;
+  terminalEl.appendChild(line);
+  terminalEl.scrollTop = terminalEl.scrollHeight;
+}
+
+function appendIssueDetails(issue) {
+  appendLine(issue.title, 'issue-title');
+  appendLine(`Severity: ${issue.severity} | Confidence: ${issue.confidence}`, 'meta');
+  appendLine(`Resource: ${issue.resourceUrl}`, 'meta');
+  if (issue.matches?.length) {
+    issue.matches.forEach((match) => {
+      appendLine(`- ${match}`, 'match');
+    });
+  }
+  if (issue.hasDownload) {
+    appendLine('Artifacts available via the popup download button.', 'meta');
+  }
+}
+
+window.addEventListener('message', (event) => {
+  if (event.origin !== EXTENSION_ORIGIN) return;
+  if (event.data?.source !== 'js-miner-popup') return;
+  const { type, payload } = event.data;
+
+  switch (type) {
+    case 'status':
+      appendLine(payload, 'status');
+      break;
+    case 'scan-start':
+      appendLine(`Running \"${payload.scanner}\" scan...`, 'status');
+      break;
+    case 'scan-results': {
+      const { scanner, issues } = payload;
+      const variant = issues.length ? 'warn' : 'success';
+      appendLine(`Completed \"${scanner}\" scan with ${issues.length} finding(s).`, variant);
+      issues.forEach((issue) => appendIssueDetails(issue));
+      break;
+    }
+    case 'summary':
+      appendLine(
+        `Finished ${payload.scanCount} scan(s) against ${payload.pageUrl} with ${payload.issueCount} total finding(s).`,
+        payload.issueCount ? 'warn' : 'success'
+      );
+      break;
+    case 'error':
+      appendLine(`Error: ${payload}`, 'error');
+      break;
+    default:
+      break;
+  }
+});
+
+function notifyPopup(type) {
+  if (!window.opener) return;
+  window.opener.postMessage({ source: 'js-miner-console', type }, EXTENSION_ORIGIN);
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  appendLine('JS Miner Console ready.', 'success');
+  notifyPopup('console-ready');
+});
+
+window.addEventListener('beforeunload', () => {
+  notifyPopup('console-closed');
+});

--- a/chrome-extension/popup.css
+++ b/chrome-extension/popup.css
@@ -64,6 +64,16 @@ details {
   overflow-y: auto;
 }
 
+.console-summary {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 6px;
+  padding: 8px 10px;
+  font-size: 12px;
+  line-height: 1.4;
+  margin-bottom: 10px;
+  color: #d4dce5;
+}
+
 .result-card {
   background: rgba(255, 255, 255, 0.06);
   border-radius: 6px;


### PR DESCRIPTION
## Summary
- add a dedicated terminal-style console page and open it from the popup when scans run
- stream status updates and sanitized scan results to the console window while keeping popup issue cards and downloads
- style the popup to reference the console output and introduce console-specific styling assets

## Testing
- Not run (Chrome extension UI update)


------
https://chatgpt.com/codex/tasks/task_e_68dabc5f3490832ca3ac91e0952a3061